### PR TITLE
fix: handling irregular UTM zones

### DIFF
--- a/minicube-generation/02-config-generation/generate-base-configs.py
+++ b/minicube-generation/02-config-generation/generate-base-configs.py
@@ -37,6 +37,19 @@ def _get_crs(lon: float, lat: float) -> str:
     if not -180 < lon < 180 or not -90 < lat < 90:
         raise ValueError("Coordinates out of range")
     utm_zone = int(math.floor(lon + 180) / 6) + 1
+    # Handle Norway 32V anomaly
+    if (56 <= lat < 64) and (3 <= lon < 6):
+        utm_zone = 32
+    # Handle Svalbard zones
+    if 72 <= lat < 84:
+        if 0 <= lon < 9:
+            utm_zone = 31
+        elif 9 <= lon < 21:
+            utm_zone = 33
+        elif 21 <= lon < 33:
+            utm_zone = 35
+        elif 33 <= lon < 42:
+            utm_zone = 37
     hemisphere = 700 if lat < 0 else 600
     epsg_code = 32000 + hemisphere + utm_zone
     return f'EPSG:{epsg_code}'


### PR DESCRIPTION
Hi again, I just came across this, regarding the UTM zones for Sentinel-2: 
the current solution does not account for handling irregular UTM zones 33v, 31, 33, 35, and 37x. while this may still lead to errors they should now be minimized.

The in #1  agreed solution with pyproj.query_utm_crs_info does not account for the larger 33v, 
in the case of Svalbard the zones are also incorrect. Choosing [0] in `return utm_crs_list[0].code` will favor the first of overlapping zones, which may lead to differences and wrong choice in the Svalbard region.

Using the [Sentinel-2 Grid](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-2/data-products) (conveniently as geoparquet [here](https://sentinels.copernicus.eu/web/sentinel/missions/sentinel-2/data-products)) could be a way to handle the crs selection and the choice of Sentinel-2 tile for a request: via contains (if possible use the tile completely containing the minicube) or via intersect.

Best